### PR TITLE
.github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+## @file
+# GitHub CODEOWNERS file
+#
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+/.azurepipelines/         michael.d.kinney@intel.com
+
+/.github/                 michael.d.kinney@intel.com
+/.github/                 sumana.venur@intel.com
+
+/.mergify/                michael.d.kinney@intel.com
+/.mergify/                erik.c.bjorge@intel.com
+
+/.pytools/                erik.c.bjorge@intel.com
+
+/FmpDevicePkg/            michael.d.kinney@intel.com
+
+/MdePkg/                  michael.d.kinney@intel.com
+
+/UnitTestFrameworkPkg/    michael.d.kinney@intel.com
+/UnitTestFrameworkPkg/    sumana.venur@intel.com
+
+/IntelFsp2Pkg/            nathaniel.l.desimone@intel.com
+/IntelFsp2WrapperPkg/     nathaniel.l.desimone@intel.com
+
+/BaseTools/               erik.c.bjorge@intel.com
+/BaseTools/               nathaniel.l.desimone@intel.com


### PR DESCRIPTION
Add sample CODEOWNERS file for GitHub
to automaticall assign code reviewers.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>